### PR TITLE
add 科目追加・詳細ダイアログを追加

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/pblt3/android/TimetableActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/pblt3/android/TimetableActivity.java
@@ -1,16 +1,21 @@
 package io.github.shun.osugi.pblt3.android;
 
 
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.app.DatePickerDialog;
 import android.content.res.ColorStateList;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.util.TypedValue;
 import android.view.Display;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Button;
-import android.widget.FrameLayout;
+import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TableLayout;
@@ -18,13 +23,17 @@ import android.widget.TableRow;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.SetOptions;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 //時間割に関するプログラム
@@ -169,6 +178,7 @@ public class TimetableActivity extends AppCompatActivity {
         }
     }
 
+    @SuppressLint("ResourceAsColor")
     private void addClass(LinearLayout linearLayout, String day, int period) {
         db.collection("timetable").document(userID).collection(day).document(String.valueOf(period)).get().addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
@@ -176,20 +186,16 @@ public class TimetableActivity extends AppCompatActivity {
                 if (snapshot.exists()) {
                     Map<String, Object> data = snapshot.getData();
                     // データ取得
-                    String subjectName = snapshot.contains("教科名") ? snapshot.getString("教科名") : "不明";
-                    String attendanceMethod = snapshot.contains("出席方法") ? snapshot.getString("出席方法") : "不明";
-                    int notificationTime = ((Long) data.getOrDefault("通知時間", -10L)).intValue();
-                    int lateTime = ((Long) data.getOrDefault("遅刻時間", 20L)).intValue();
+                    String subjectName = snapshot.contains("教科名") ? snapshot.getString("教科名") : "未設定";
+                    String attendanceMethod1 = snapshot.contains("出席方法1") ? snapshot.getString("出席方法1") : "未設定";
+                    String attendanceMethod2 = snapshot.contains("出席方法2") ? snapshot.getString("出席方法2") : "未設定";
+                    String attendanceMethod3 = snapshot.contains("出席方法3") ? snapshot.getString("出席方法3") : "未設定";
+                    Integer notificationTime1 = ((Long) data.getOrDefault("通知時間1", -10L)).intValue();
+                    Integer notificationTime2 = ((Long) data.getOrDefault("通知時間2", -10L)).intValue();
+                    Integer notificationTime3 = ((Long) data.getOrDefault("通知時間3", -10L)).intValue();
+                    Integer lateTime = ((Long) data.getOrDefault("遅刻時間", 20L)).intValue();
                     Boolean danger = snapshot.contains("危険") ? snapshot.getBoolean("危険") : false;
                     Map<String, Object> scheduleMap = (Map<String, Object>) snapshot.get("授業日程");
-                    if (scheduleMap != null) {
-                        for (String key : scheduleMap.keySet()) {
-                            Map<String, Object> lesson = (Map<String, Object>) scheduleMap.get(key);
-                            String lessonDate = (String) lesson.get("授業日");
-                            Boolean attendance = (Boolean) lesson.get("出欠");
-                            Boolean late = (Boolean) lesson.get("遅刻");
-                        }
-                    }
 
                     // ボタンを追加
                     Button classButton = new Button(this);
@@ -203,6 +209,187 @@ public class TimetableActivity extends AppCompatActivity {
                     // 科目の詳細ダイアログを表示
                     classButton.setOnClickListener(showClassDetails -> {
 
+                        // カスタムレイアウトのビューを読み込む
+                        LayoutInflater inflater = LayoutInflater.from(this);
+                        View dialogView = inflater.inflate(R.layout.edit_dialog, null);
+                        dialogView.setBackgroundColor(danger == false ? ContextCompat.getColor(this, R.color.cyan) : ContextCompat.getColor(this, R.color.red));
+
+                        // 各UI要素を取得
+                        TextView title = dialogView.findViewById(R.id.title);
+                        title.setText(day + "曜" + period + "限");
+
+                        EditText subjectNameEdit = dialogView.findViewById(R.id.subjectName);
+                        Button deleteButton = dialogView.findViewById(R.id.optionButton);
+                        EditText startDate = dialogView.findViewById(R.id.startDate);
+                        Button detailButton = dialogView.findViewById(R.id.detailButton);
+                        CheckBox check1 = dialogView.findViewById(R.id.check1);
+                        CheckBox check2 = dialogView.findViewById(R.id.check2);
+                        CheckBox check3 = dialogView.findViewById(R.id.check3);
+                        EditText attendanceMethodEdit1 = dialogView.findViewById(R.id.attendanceMethod1);
+                        EditText attendanceMethodEdit2 = dialogView.findViewById(R.id.attendanceMethod2);
+                        EditText attendanceMethodEdit3 = dialogView.findViewById(R.id.attendanceMethod3);
+                        EditText notificationTimeEdit1 = dialogView.findViewById(R.id.notificationTime1);
+                        EditText notificationTimeEdit2 = dialogView.findViewById(R.id.notificationTime2);
+                        EditText notificationTimeEdit3 = dialogView.findViewById(R.id.notificationTime3);
+                        TextView lateTimeEdit = dialogView.findViewById(R.id.lateTime);
+                        Button saveButton = dialogView.findViewById(R.id.saveButton);
+
+                        subjectNameEdit.setText(subjectName);
+                        attendanceMethodEdit1.setText(attendanceMethod1);
+                        attendanceMethodEdit2.setText(attendanceMethod2);
+                        attendanceMethodEdit3.setText(attendanceMethod3);
+                        notificationTimeEdit1.setText(notificationTime1.toString());
+                        notificationTimeEdit2.setText(notificationTime2.toString());
+                        notificationTimeEdit3.setText(notificationTime3.toString());
+                        lateTimeEdit.setText(lateTime.toString());
+
+                        // 開始日入力の設定
+                        Calendar calendar = Calendar.getInstance(); // 今日の日付を取得
+                        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                        String todayDate = dateFormat.format(calendar.getTime());
+
+                        if (scheduleMap != null && scheduleMap.containsKey("第1回")) {
+                            Map<String, Object> firstLesson = (Map<String, Object>) scheduleMap.get("第1回");
+                            String firstLessonDate = (String) firstLesson.get("授業日");
+                            if (firstLessonDate != null && !firstLessonDate.isEmpty()) {startDate.setText(firstLessonDate);}
+                        } else {startDate.setText(todayDate);}
+
+                        startDate.setText(todayDate);
+                        startDate.setOnClickListener(v -> {
+                            // DatePickerDialogを表示
+                            DatePickerDialog datePickerDialog = new DatePickerDialog(this,
+                                    (view, year, month, dayOfMonth) -> {
+                                        // 日付が選択されたときの処理
+                                        String selectedDate = String.format("%04d-%02d-%02d", year, month + 1, dayOfMonth);
+                                        startDate.setText(selectedDate); // 選択した日付をセット
+                                    },
+                                    calendar.get(Calendar.YEAR),
+                                    calendar.get(Calendar.MONTH),
+                                    calendar.get(Calendar.DAY_OF_MONTH)
+                            );
+
+                            datePickerDialog.show();
+                        });
+
+                        // チェックボックスの設定
+                        check1.setChecked(true);
+                        check1.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                            attendanceMethodEdit1.setEnabled(isChecked);
+                            notificationTimeEdit1.setEnabled(isChecked);
+                            if (!isChecked) {
+                                attendanceMethodEdit1.setText(null);
+                                notificationTimeEdit1.setText(null);
+                            }
+                        });
+
+                        check2.setChecked(true);
+                        check2.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                            attendanceMethodEdit2.setEnabled(isChecked);
+                            notificationTimeEdit2.setEnabled(isChecked);
+                            if (!isChecked) {
+                                attendanceMethodEdit2.setText(null);
+                                notificationTimeEdit2.setText(null);
+                            }
+                        });
+
+                        check3.setChecked(true);
+                        check3.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                            attendanceMethodEdit3.setEnabled(isChecked);
+                            notificationTimeEdit3.setEnabled(isChecked);
+                            if (!isChecked) {
+                                attendanceMethodEdit3.setText(null);
+                                notificationTimeEdit3.setText(null);
+                            }
+                        });
+
+                        attendanceMethodEdit1.setEnabled(check1.isChecked());
+                        notificationTimeEdit1.setEnabled(check1.isChecked());
+
+                        attendanceMethodEdit2.setEnabled(check2.isChecked());
+                        notificationTimeEdit2.setEnabled(check2.isChecked());
+
+                        attendanceMethodEdit3.setEnabled(check3.isChecked());
+                        notificationTimeEdit3.setEnabled(check3.isChecked());
+
+                        // ダイアログを作成
+                        AlertDialog dialog = new AlertDialog.Builder(this)
+                                .setView(dialogView)
+                                .setCancelable(true)
+                                .create();
+
+                        saveButton.setOnClickListener(v -> {
+                            String newSubjectName = subjectNameEdit.getText().toString().trim();
+                            String newStartDate = startDate.getText().toString().trim();
+                            Map<String, Map<String, String>> startDateMap = mapDates(newStartDate);
+
+                            // 出席方法1、2、3のチェック
+                            String newAttendanceMethod1 = attendanceMethodEdit1.getText().toString().trim();
+                            String newAttendanceMethod2 = attendanceMethodEdit2.getText().toString().trim();
+                            String newAttendanceMethod3 = attendanceMethodEdit3.getText().toString().trim();
+
+                            // 通知時間のパース
+                            Integer newNotificationTime1 = parseIntegerOrNull(notificationTimeEdit1.getText().toString().trim());
+                            Integer newNotificationTime2 = parseIntegerOrNull(notificationTimeEdit2.getText().toString().trim());
+                            Integer newNotificationTime3 = parseIntegerOrNull(notificationTimeEdit3.getText().toString().trim());
+
+                            // 遅刻時間のパース
+                            Integer newLateTime = parseIntegerOrNull(lateTimeEdit.getText().toString().trim());
+
+                            // classコレクションに保存
+                            String classDocumentId = db.collection("class").document().getId();
+                            Map<String, Object> classData = new HashMap<>();
+                            classData.put("教科名", newSubjectName);
+                            classData.put("授業開始日", newStartDate);
+                            classData.put("出席方法1", newAttendanceMethod1.isEmpty() ? null : newAttendanceMethod1);
+                            classData.put("出席方法2", newAttendanceMethod2.isEmpty() ? null : newAttendanceMethod2);
+                            classData.put("出席方法3", newAttendanceMethod3.isEmpty() ? null : newAttendanceMethod3);
+                            classData.put("通知時間1", newNotificationTime1);
+                            classData.put("通知時間2", newNotificationTime2);
+                            classData.put("通知時間3", newNotificationTime3);
+                            classData.put("遅刻時間", newLateTime);
+
+                            db.collection("class").document(classDocumentId)
+                                    .collection(day)
+                                    .document(String.valueOf(period))
+                                    .set(classData, SetOptions.merge())
+                                    .addOnSuccessListener(aVoid -> {loadTimetable();})
+                                    .addOnFailureListener(e -> {showError("Failed to save class details: " + e.getMessage());});
+
+                            // timetableコレクションに保存
+                            Map<String, Object> timetableData = new HashMap<>();
+                            timetableData.put("教科名", newSubjectName);
+                            timetableData.put("授業日程", startDateMap);
+                            timetableData.put("出席方法1", newAttendanceMethod1.isEmpty() ? null : newAttendanceMethod1);
+                            timetableData.put("出席方法2", newAttendanceMethod2.isEmpty() ? null : newAttendanceMethod2);
+                            timetableData.put("出席方法3", newAttendanceMethod3.isEmpty() ? null : newAttendanceMethod3);
+                            timetableData.put("通知時間1", newNotificationTime1);
+                            timetableData.put("通知時間2", newNotificationTime2);
+                            timetableData.put("通知時間3", newNotificationTime3);
+                            timetableData.put("遅刻時間", newLateTime);
+                            timetableData.put("危険" , false);
+
+                            db.collection("timetable").document(userID)
+                                    .collection(day)
+                                    .document(String.valueOf(period))
+                                    .set(timetableData, SetOptions.merge())
+                                    .addOnSuccessListener(aVoid -> {loadTimetable();})
+                                    .addOnFailureListener(e -> {showError("Failed to save class details: " + e.getMessage());});
+                            dialog.dismiss();
+                            loadTimetable();
+                        });
+
+                        // 時間割から削除
+                        deleteButton.setText("削除");
+                        deleteButton.setOnClickListener(delete -> {
+                            db.collection("timetable")
+                                    .document(userID)
+                                    .collection(day)          // 曜日
+                                    .document(String.valueOf(period)) // 期間
+                                    .delete();
+                            dialog.dismiss();
+                            loadTimetable();
+                        });
+                        dialog.show();
                     });
                     linearLayout.addView(classButton);
 
@@ -219,11 +406,168 @@ public class TimetableActivity extends AppCompatActivity {
                     // 科目の追加ダイアログを表示
                     emptyButton.setOnClickListener(addClassDetail -> {
 
+                        // カスタムレイアウトのビューを読み込む
+                        LayoutInflater inflater = LayoutInflater.from(this);
+                        View dialogView = inflater.inflate(R.layout.edit_dialog, null);
+                        dialogView.setBackgroundColor(ContextCompat.getColor(this, R.color.white));
+
+                        // 各UI要素を取得
+                        TextView title = dialogView.findViewById(R.id.title);
+                        title.setText(day + "曜" + period + "限");
+
+                        EditText subjectNameEdit = dialogView.findViewById(R.id.subjectName);
+                        Button registeredClassesButton = dialogView.findViewById(R.id.optionButton);
+                        EditText startDate = dialogView.findViewById(R.id.startDate);
+                        Button detailButton = dialogView.findViewById(R.id.detailButton);
+                        CheckBox check1 = dialogView.findViewById(R.id.check1);
+                        CheckBox check2 = dialogView.findViewById(R.id.check2);
+                        CheckBox check3 = dialogView.findViewById(R.id.check3);
+                        EditText attendanceMethodEdit1 = dialogView.findViewById(R.id.attendanceMethod1);
+                        EditText attendanceMethodEdit2 = dialogView.findViewById(R.id.attendanceMethod2);
+                        EditText attendanceMethodEdit3 = dialogView.findViewById(R.id.attendanceMethod3);
+                        EditText notificationTimeEdit1 = dialogView.findViewById(R.id.notificationTime1);
+                        EditText notificationTimeEdit2 = dialogView.findViewById(R.id.notificationTime2);
+                        EditText notificationTimeEdit3 = dialogView.findViewById(R.id.notificationTime3);
+                        TextView lateTimeEdit = dialogView.findViewById(R.id.lateTime);
+                        Button saveButton = dialogView.findViewById(R.id.saveButton);
+
+                        // 開始日入力の設定
+                        Calendar calendar = Calendar.getInstance(); // 今日の日付を取得
+                        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                        String todayDate = dateFormat.format(calendar.getTime());
+                        startDate.setText(todayDate);
+                        startDate.setOnClickListener(v -> {
+                            // DatePickerDialogを表示
+                            DatePickerDialog datePickerDialog = new DatePickerDialog(this,
+                                    (view, year, month, dayOfMonth) -> {
+                                        // 日付が選択されたときの処理
+                                        String selectedDate = String.format("%04d-%02d-%02d", year, month + 1, dayOfMonth);
+                                        startDate.setText(selectedDate); // 選択した日付をセット
+                                    },
+                                    calendar.get(Calendar.YEAR),
+                                    calendar.get(Calendar.MONTH),
+                                    calendar.get(Calendar.DAY_OF_MONTH)
+                            );
+
+                            datePickerDialog.show();
+                        });
+
+                        // みんなの登録ダイアログを表示
+                        registeredClassesButton.setText("みんなの登録");
+
+                        // 詳細設定を非表示
+                        detailButton.setVisibility(View.GONE);
+
+                        // チェックボックスの設定
+                        check1.setChecked(true);
+                        check1.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                            attendanceMethodEdit1.setEnabled(isChecked);
+                            notificationTimeEdit1.setEnabled(isChecked);
+                            if (!isChecked) {
+                                attendanceMethodEdit1.setText(null);
+                                notificationTimeEdit1.setText(null);
+                            }
+                        });
+
+                        check2.setChecked(true);
+                        check2.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                            attendanceMethodEdit2.setEnabled(isChecked);
+                            notificationTimeEdit2.setEnabled(isChecked);
+                            if (!isChecked) {
+                                attendanceMethodEdit2.setText(null);
+                                notificationTimeEdit2.setText(null);
+                            }
+                        });
+
+                        check3.setChecked(true);
+                        check3.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                            attendanceMethodEdit3.setEnabled(isChecked);
+                            notificationTimeEdit3.setEnabled(isChecked);
+                            if (!isChecked) {
+                                attendanceMethodEdit3.setText(null);
+                                notificationTimeEdit3.setText(null);
+                            }
+                        });
+
+                        attendanceMethodEdit1.setEnabled(check1.isChecked());
+                        notificationTimeEdit1.setEnabled(check1.isChecked());
+
+                        attendanceMethodEdit2.setEnabled(check2.isChecked());
+                        notificationTimeEdit2.setEnabled(check2.isChecked());
+
+                        attendanceMethodEdit3.setEnabled(check3.isChecked());
+                        notificationTimeEdit3.setEnabled(check3.isChecked());
+
+                        // ダイアログを作成
+                        AlertDialog dialog = new AlertDialog.Builder(this)
+                                .setView(dialogView)
+                                .setCancelable(true)
+                                .create();
+
+                        saveButton.setOnClickListener(v -> {
+                            String newSubjectName = subjectNameEdit.getText().toString().trim();
+                            String newStartDate = startDate.getText().toString().trim();
+                            Map<String, Map<String, String>> startDateMap = mapDates(newStartDate);
+
+                            // 出席方法1、2、3のチェック
+                            String newAttendanceMethod1 = attendanceMethodEdit1.getText().toString().trim();
+                            String newAttendanceMethod2 = attendanceMethodEdit2.getText().toString().trim();
+                            String newAttendanceMethod3 = attendanceMethodEdit3.getText().toString().trim();
+
+                            // 通知時間のパース
+                            Integer newNotificationTime1 = parseIntegerOrNull(notificationTimeEdit1.getText().toString().trim());
+                            Integer newNotificationTime2 = parseIntegerOrNull(notificationTimeEdit2.getText().toString().trim());
+                            Integer newNotificationTime3 = parseIntegerOrNull(notificationTimeEdit3.getText().toString().trim());
+
+                            // 遅刻時間のパース
+                            Integer newLateTime = parseIntegerOrNull(lateTimeEdit.getText().toString().trim());
+
+                            // classコレクションに保存
+                            String classDocumentId = db.collection("class").document().getId();
+                            Map<String, Object> classData = new HashMap<>();
+                            classData.put("教科名", newSubjectName);
+                            classData.put("授業開始日", newStartDate);
+                            classData.put("出席方法1", newAttendanceMethod1.isEmpty() ? null : newAttendanceMethod1);
+                            classData.put("出席方法2", newAttendanceMethod2.isEmpty() ? null : newAttendanceMethod2);
+                            classData.put("出席方法3", newAttendanceMethod3.isEmpty() ? null : newAttendanceMethod3);
+                            classData.put("通知時間1", newNotificationTime1);
+                            classData.put("通知時間2", newNotificationTime2);
+                            classData.put("通知時間3", newNotificationTime3);
+                            classData.put("遅刻時間", newLateTime);
+
+                            db.collection("class").document(classDocumentId)
+                                    .collection(day)
+                                    .document(String.valueOf(period))
+                                    .set(classData, SetOptions.merge())
+                                    .addOnSuccessListener(aVoid -> {loadTimetable();})
+                                    .addOnFailureListener(e -> {showError("Failed to save class details: " + e.getMessage());});
+
+                            // timetableコレクションに保存
+                            Map<String, Object> timetableData = new HashMap<>();
+                            timetableData.put("教科名", newSubjectName);
+                            timetableData.put("授業日程", startDateMap);
+                            timetableData.put("出席方法1", newAttendanceMethod1.isEmpty() ? null : newAttendanceMethod1);
+                            timetableData.put("出席方法2", newAttendanceMethod2.isEmpty() ? null : newAttendanceMethod2);
+                            timetableData.put("出席方法3", newAttendanceMethod3.isEmpty() ? null : newAttendanceMethod3);
+                            timetableData.put("通知時間1", newNotificationTime1);
+                            timetableData.put("通知時間2", newNotificationTime2);
+                            timetableData.put("通知時間3", newNotificationTime3);
+                            timetableData.put("遅刻時間", newLateTime);
+
+                            db.collection("timetable").document(userID)
+                                    .collection(day)
+                                    .document(String.valueOf(period))
+                                    .set(timetableData, SetOptions.merge())
+                                    .addOnSuccessListener(aVoid -> {loadTimetable();})
+                                    .addOnFailureListener(e -> {showError("Failed to save class details: " + e.getMessage());});
+                            dialog.dismiss();
+                            loadTimetable();
+                        });
+                        dialog.show();
                     });
                     linearLayout.addView(emptyButton);
                 }
             } else {
-                // Handle error
                 showError("Failed to load timetable.");
             }
         });
@@ -247,5 +591,35 @@ public class TimetableActivity extends AppCompatActivity {
         TextView errorText = findViewById(R.id.error_text);
         errorText.setText(message);
         errorText.setVisibility(View.VISIBLE);
+    }
+
+    private Map<String, Map<String, String>> mapDates(String startDate) {
+        Map<String, Map<String, String>> dateMap = new HashMap<>();
+        try {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(dateFormat.parse(startDate)); // 入力された日付を設定
+
+            for (int i = 1; i <= 15; i++) {
+                String date = dateFormat.format(calendar.getTime());
+                Map<String, String> eachdateMap = new HashMap<>();
+                eachdateMap.put("授業日", date);
+                dateMap.put("第" + i + "回", eachdateMap);
+                calendar.add(Calendar.DAY_OF_MONTH, 7);
+            }
+
+        } catch (ParseException e) {
+            showError("Invalid start date format: " + e.getMessage());
+        }
+
+        return dateMap;
+    }
+
+    private Integer parseIntegerOrNull(String input) {
+        try {
+            return input.isEmpty() ? null : Integer.parseInt(input);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/app/src/main/res/layout/edit_dialog.xml
+++ b/app/src/main/res/layout/edit_dialog.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="300dp"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:padding="16dp"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    android:background="@color/cyan">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="○曜 x限"
+            android:textSize="14sp"
+            android:textColor="@android:color/black"
+            android:gravity="start" />
+
+        <Button
+            android:id="@+id/optionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:minHeight="0dp"
+            android:padding="8dp"/>
+
+    </LinearLayout>
+
+    <EditText
+        android:id="@+id/subjectName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="教科名を入力"
+        android:textSize="16sp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        >
+
+        <EditText
+            android:id="@+id/startDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="YYYY-MM-DD"
+            android:textSize="16sp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="~"
+            android:textSize="16sp" />
+
+        <Button
+            android:id="@+id/detailButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="詳細設定"
+            android:textSize="12sp"
+            android:layout_marginLeft="16dp"
+            android:minHeight="0dp"
+            android:padding="8dp"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        >
+
+        <CheckBox
+            android:id="@+id/check1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/attendanceMethod1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="通知方法"
+            android:textSize="16sp"
+            android:layout_weight="1"/>
+
+        <EditText
+            android:id="@+id/notificationTime1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="10"
+            android:textSize="16sp"
+            android:layout_weight="0.2"
+            android:gravity="center" />
+
+        <TextView
+            android:id="@+id/nortificationTimeString1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="分前"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        >
+
+        <CheckBox
+            android:id="@+id/check2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/attendanceMethod2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="通知方法"
+            android:textSize="16sp"
+            android:layout_weight="1"/>
+
+        <EditText
+            android:id="@+id/notificationTime2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="10"
+            android:textSize="16sp"
+            android:layout_weight="0.2"
+            android:gravity="center"
+            />
+
+        <TextView
+            android:id="@+id/nortificationTimeString2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="分前"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        >
+
+        <CheckBox
+            android:id="@+id/check3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/attendanceMethod3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="通知方法"
+            android:textSize="16sp"
+            android:layout_weight="1"/>
+
+        <EditText
+            android:id="@+id/notificationTime3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="10"
+            android:textSize="16sp"
+            android:layout_weight="0.2"
+            android:gravity="center"
+            />
+
+        <TextView
+            android:id="@+id/nortificationTimeString3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="分前"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center"
+        >
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="遅刻時間"
+            android:textSize="12sp" />
+
+        <EditText
+            android:id="@+id/lateTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="20"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/lateTimeString"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="分後"
+            android:textSize="12sp" />
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/saveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="保存"
+        android:textSize="12sp"
+        android:textAlignment="center"
+        android:layout_gravity="center"
+        android:minHeight="0dp"
+        android:padding="8dp"/>
+
+</LinearLayout>


### PR DESCRIPTION
科目追加ダイアログ、科目詳細ダイアログを追加

未登録の時限を押すと、科目追加ダイアログ、登録済みの時限を押すと、科目詳細ダイアログが表示される。
どちらもedit_dialog.xmlを使用。
各ダイアログでは、情報の保存・変更が可能。
授業日程の詳細設定は未実装。

現状、すべての項目に正しい値を入れないとエラーが生じるため注意。（保存はできるが読み込み時にエラーが生じるため、データベースから手動で削除することで回復できる。）
新規追加で、classコレクションとtimetableコレクションに科目が追加され、削除を行うと、timetableコレクションからのみ削除されるようになっている。