### PR TITLE
fix 出席確認画面で月曜日が最後尾になってしまう問題を修正

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/pblt3/android/AttendanceActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/pblt3/android/AttendanceActivity.java
@@ -77,8 +77,6 @@ public class AttendanceActivity extends AppCompatActivity {
                             int period2 = Integer.parseInt(doc2.getId().replaceAll("\\D", ""));
                             return Integer.compare(period1, period2);
                         });
-                        // 月曜日のデータを表示
-                        addDayLayout("月", periods);
                     }
 
                     // 月曜日のデータがロードされたら、次に他の曜日を順番通りにロード
@@ -86,7 +84,7 @@ public class AttendanceActivity extends AppCompatActivity {
                     completedDays.add("月"); // 月曜日が最初なので先に追加
 
                     // 火曜日から日曜日までの曜日データを順番に処理
-                    for (int i = 1; i < daysOfWeek.length; i++) {
+                    for (int i = 0; i < daysOfWeek.length; i++) {
                         String day = daysOfWeek[i];
                         db.collection("timetable").document(userID).collection(day).get()
                                 .addOnCompleteListener(task2 -> {


### PR DESCRIPTION
出席確認画面で月曜日が最後尾になってしまう問題を修正

completedDaysに月を先に加えるのは残したまま、月曜日もfor文の中で追加するようにしたらなぜかできた。